### PR TITLE
[Feat] 이중 레이캐스트를 통한 좌우 충돌검사 및 충돌 가능한 회전 구현

### DIFF
--- a/Assets/YSH/Prefabs/BoxBlock.prefab
+++ b/Assets/YSH/Prefabs/BoxBlock.prefab
@@ -415,7 +415,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1000
+  m_Mass: 1
   m_LinearDrag: 2
   m_AngularDrag: 0.001
   m_GravityScale: 1

--- a/Assets/YSH/Prefabs/BoxBlock.prefab
+++ b/Assets/YSH/Prefabs/BoxBlock.prefab
@@ -397,6 +397,7 @@ MonoBehaviour:
   castLayer:
     serializedVersion: 2
     m_Bits: 12288
+  rotateSpeed: 990
 --- !u!50 &7382279234303379018
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/YSH/Prefabs/BoxBlock.prefab
+++ b/Assets/YSH/Prefabs/BoxBlock.prefab
@@ -353,7 +353,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7382279234303379016
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/YSH/Prefabs/BoxBlock.prefab
+++ b/Assets/YSH/Prefabs/BoxBlock.prefab
@@ -353,7 +353,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &7382279234303379016
 Transform:
   m_ObjectHideFlags: 0
@@ -385,8 +385,8 @@ MonoBehaviour:
   basicFallSpeed: -1
   fastFallSpeed: -3
   spotlightPrefab: {fileID: 0}
-  moveAmount: 0.5
-  pushAmount: 1
+  moveAmount: 0.25
+  pushAmount: 0.5
   rotateAmount: 90
   moveDelay: 0.08
   tiles:
@@ -394,12 +394,6 @@ MonoBehaviour:
   - {fileID: 4930956799322085760}
   - {fileID: 4930956797943152147}
   - {fileID: 4930956799183455669}
-  tileParent: {fileID: 7382279234949916265}
-  tileRotPos:
-  - {x: -0.75, y: -0.25}
-  - {x: -0.75, y: 0.75}
-  - {x: 0.25, y: 0.75}
-  - {x: 0.25, y: -0.25}
   castLayer:
     serializedVersion: 2
     m_Bits: 12288
@@ -449,7 +443,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7382279234949916278}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.25, y: -0.25, z: 0}
+  m_LocalPosition: {x: -0.25, y: 0.25, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/YSH/Prefabs/StraightBlock.prefab
+++ b/Assets/YSH/Prefabs/StraightBlock.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5564063098573158909
 Transform:
   m_ObjectHideFlags: 0
@@ -316,7 +316,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.9738907, y: 0.47678435}
+  m_Size: {x: 1.9865887, y: 0.48677358}
   m_EdgeRadius: 0
 --- !u!1 &5564063099733971883
 GameObject:

--- a/Assets/YSH/Prefabs/StraightBlock.prefab
+++ b/Assets/YSH/Prefabs/StraightBlock.prefab
@@ -61,6 +61,7 @@ MonoBehaviour:
   castLayer:
     serializedVersion: 2
     m_Bits: 12288
+  rotateSpeed: 990
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/YSH/Prefabs/StraightBlock.prefab
+++ b/Assets/YSH/Prefabs/StraightBlock.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &5564063098573158909
 Transform:
   m_ObjectHideFlags: 0
@@ -49,8 +49,8 @@ MonoBehaviour:
   basicFallSpeed: -1
   fastFallSpeed: -3
   spotlightPrefab: {fileID: 0}
-  moveAmount: 0.5
-  pushAmount: 1
+  moveAmount: 0.25
+  pushAmount: 0.5
   rotateAmount: 90
   moveDelay: 0.08
   tiles:
@@ -58,12 +58,6 @@ MonoBehaviour:
   - {fileID: 5564063099733971883}
   - {fileID: 5564063098824068280}
   - {fileID: 5564063099002927774}
-  tileParent: {fileID: 5564063099151194588}
-  tileRotPos:
-  - {x: -1, y: -0.75}
-  - {x: -1.75, y: 0.25}
-  - {x: -0.5, y: 0.75}
-  - {x: 0.25, y: -0.25}
   castLayer:
     serializedVersion: 2
     m_Bits: 12288
@@ -281,7 +275,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5564063099151194563}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.25, y: -0.25, z: 0}
+  m_LocalPosition: {x: -0.75, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -14,13 +14,9 @@ public class Blocks : MonoBehaviour
     [SerializeField] private float rotateAmount;            // 회전량
     [SerializeField] private float moveDelay;               // 이동 시 부여할 딜레이
     [SerializeField] private GameObject[] tiles;            // 블럭 타일들
-    [SerializeField] private Transform tileParent;          // 타일들의 부모 트랜스폼
-    [SerializeField] private Vector2[] tileRotPos;          // 회전시 적용할 위치값들
     [SerializeField] private LayerMask castLayer;           // 레이캐스트용 layermask
 
-    private int rotIndex = 0;               // tileRotPos 배열에서 사용할 index값
     private Rigidbody2D rigid;              // Rigidbody2D 컴포넌트 참조                                          
-
     private Vector2 currentVelocity;        // 현재 하강 속도
     private Vector2 currentDirection;       // 현재 이동 방향
     private float currentAmount;            // 현재 이동량
@@ -104,17 +100,6 @@ public class Blocks : MonoBehaviour
 
         // z축으로 rotateAmount 만큼 회전
         transform.Rotate(Vector3.forward, rotateAmount);
-
-        // 회전시 적용할 위치값을 설정하지 않았으면 여기서 return
-        if (tileRotPos.Length == 0)
-            return;
-
-        // tile Parent의 위치를 적용
-        tileParent.localPosition = tileRotPos[rotIndex++];
-
-        // 360도 회전을 모두 진행했다면 다시 처음으로 
-        if (rotIndex >= tileRotPos.Length)
-            rotIndex = 0;
     }
 
     // 실제 이동, 밀치기를 진행
@@ -281,10 +266,10 @@ public class Blocks : MonoBehaviour
 
         for (int i = 0; i < tiles.Length; i++)
         {
-            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.up * 0.22f), Vector3.left * 0.45f);
-            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.down * 0.22f), Vector3.left * 0.45f);
-            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.up * 0.22f), Vector3.right * 0.45f);
-            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.down * 0.22f), Vector3.right * 0.45f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.up * 0.22f), Vector3.left * 0.2f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.down * 0.22f), Vector3.left * 0.2f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.up * 0.22f), Vector3.right * 0.2f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.down * 0.22f), Vector3.right * 0.2f);
         }
     }
 }

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -13,15 +13,12 @@ public class Blocks : MonoBehaviour
     [SerializeField] private float pushAmount;              // 밀치기 이동량
     [SerializeField] private float rotateAmount;            // 회전량
     [SerializeField] private float moveDelay;               // 이동 시 부여할 딜레이
-
     [SerializeField] private GameObject[] tiles;            // 블럭 타일들
     [SerializeField] private Transform tileParent;          // 타일들의 부모 트랜스폼
     [SerializeField] private Vector2[] tileRotPos;          // 회전시 적용할 위치값들
-
-    [SerializeField] LayerMask castLayer; 
+    [SerializeField] private LayerMask castLayer;           // 레이캐스트용 layermask
 
     private int rotIndex = 0;               // tileRotPos 배열에서 사용할 index값
-
     private Rigidbody2D rigid;              // Rigidbody2D 컴포넌트 참조                                          
 
     private Vector2 currentVelocity;        // 현재 하강 속도
@@ -147,18 +144,24 @@ public class Blocks : MonoBehaviour
     // 추가로 좌우 이동 시 충돌 감지 후 충돌을 처리한다.
     private IEnumerator MoveRoutine()
     {
-        Vector2 movePos;
-        Vector2 lastDir;
-        float lastAmount;
-        Vector2 toHit;
-        RaycastHit2D[] result;
-        Vector2 startPos;
+        Vector2 lastDir; // 움직일 방향
+        float lastAmount; // 움직일 양
+        Vector2 moveDist; // 움직일 거리
 
-        lastDir = currentDirection;
+        RaycastHit2D hit1; // 위쪽 체크 결과
+        RaycastHit2D hit2; // 아래쪽 체크 결과
+        Vector2 startPos1; // 위쪽 시작 위치
+        Vector2 startPos2; // 아래쪽 시작 위치
+
+        RaycastHit2D resultHit; // 최종적으로 선정된 충돌 결과 (위쪽과 아래쪽을 판별해서 최종적으로 선정)
+        Vector2 resultStartPos; // 최종적으로 선정된 시작 위치 (동일)
+
+        Vector2 toHit; // 감지 시작 위치 -> 감지된 위치로 향하는 벡터
+
         // 제어가 가능할 동안 루프
         while (isControllable)
         {
-            movePos = currentDirection * currentAmount;
+            moveDist = currentDirection * currentAmount;
             lastDir = currentDirection;
             lastAmount = currentAmount;
 
@@ -167,42 +170,65 @@ public class Blocks : MonoBehaviour
             for (int i = 0; i < tiles.Length; i++)
             {
                 // 각 타일의 위치로부터 이동할 방향으로 raycast
-                startPos = (Vector2)tiles[i].transform.position + lastDir * 0.25f;
-                result = Physics2D.RaycastAll(startPos, lastDir, lastAmount-0.05f, castLayer);
-                foreach(RaycastHit2D hit in result)
+                startPos1 = (Vector2)tiles[i].transform.position + (lastDir * 0.25f) + (Vector2.up * 0.22f);
+                startPos2 = (Vector2)tiles[i].transform.position + (lastDir * 0.25f) + (Vector2.down * 0.22f);
+                hit1 = Physics2D.Raycast(startPos1, lastDir, lastAmount - 0.05f, castLayer);
+                hit2 = Physics2D.Raycast(startPos2, lastDir, lastAmount - 0.05f, castLayer);
+
+                // 충돌감지가 하나라도 됐는지 확인
+                if (hit1.collider == null && hit2.collider == null)
+                    continue;
+
+                // 둘다 감지 된 경우
+                if (hit1.collider != null && hit2.collider != null)
                 {
-                    // 부모 오브젝트가 hit된다면 해당 타일은 중간에 끼인 타일이므로 넘어간다.
-                    if (hit.transform == transform)
-                        break;
-
-                    // 제어권을 해제
-                    isControllable = false;
-
-                    // 충돌 검사를 시작한 위치로 부터 충돌한 지점까지의 거리를 확인
-                    toHit = hit.point - startPos;
-                    // 충돌은 감지했지만 위치가 딱 붙어있지 않는 경우
-                    // (밀치기의 경우 왼쪽 2칸까지 (1f) 범위이기 때문에 필요한 조건)
-                    if (toHit.magnitude > 0.01f)
-                    {
-                        Debug.Log("pos calibration");
-                        // 블록의 위치를 보정해준다.
-                        transform.position += new Vector3(toHit.x, 0, 0);
-                    }
-
-                    // for debug
-                    Debug.Log($"Horizontal Collision : {tiles[i].name} > {hit.collider.name}");
-                    Debug.Log($"origin : {(Vector2)tiles[i].transform.position}, direction : {lastDir}");
-                    SpriteRenderer sr = tiles[i].GetComponent<SpriteRenderer>();
-                    sr.color = Color.red;
-
-                    yield break;
+                    resultHit = hit1.distance <= hit2.distance ? hit1 : hit2;
+                    resultStartPos = hit1.distance <= hit2.distance ? startPos1 : startPos2;
                 }
+                // hit1이 감지된 경우
+                else if (hit1.collider != null)
+                {
+                    resultHit = hit1;
+                    resultStartPos = startPos1;
+                }
+                // hit2가 감지된 경우
+                else
+                {
+                    resultHit = hit2;
+                    resultStartPos = startPos2;
+                }
+                
+                // 부모 오브젝트가 hit된다면 해당 타일은 중간에 끼인 타일이므로 넘어간다.
+                if (resultHit.transform == transform)
+                    continue;
+
+                // 제어권을 해제
+                isControllable = false;
+
+                // 충돌 검사를 시작한 위치로 부터 충돌한 지점까지의 거리를 확인
+                toHit = resultHit.point - resultStartPos;
+                // 충돌은 감지했지만 위치가 딱 붙어있지 않는 경우
+                // (밀치기의 경우 왼쪽 2칸까지 (1f) 범위이기 때문에 필요한 조건)
+                if (toHit.magnitude > 0.01f)
+                {
+                    Debug.Log("pos calibration");
+                    // 블록의 위치를 보정해준다.
+                    transform.position += new Vector3(toHit.x, 0, 0);
+                }
+
+                // for debug
+                Debug.Log($"Horizontal Collision : {tiles[i].name} > {resultHit.collider.name}");
+                Debug.Log($"origin : {(Vector2)tiles[i].transform.position}, direction : {lastDir}");
+                SpriteRenderer sr = tiles[i].GetComponent<SpriteRenderer>();
+                sr.color = Color.red;
+
+                yield break;
             }
 
             Debug.Log("No Collision");
 
             // 순간적으로 이동해야 하므로 position값을 변경한다.
-            rigid.position += movePos;
+            rigid.position += moveDist;
 
             // delay만큼 대기
             yield return wsMoveDelay;
@@ -214,9 +240,6 @@ public class Blocks : MonoBehaviour
 
     private void OnCollisionEnter2D(Collision2D other)
     {
-        if (isControllable)
-            rigid.velocity = Vector2.zero;
-
         // 충돌한 면이 other의 윗면인지 확인
         if (other.contacts[0].normal.y >= 0.9f)
         {
@@ -233,8 +256,14 @@ public class Blocks : MonoBehaviour
         {
             Debug.Log("not entered");
         }
-        // 충돌 시 flag 변경 (레이어로 특정 물체 구분 필요?)
-        isControllable = false;
+
+        if (isControllable)
+        {
+            rigid.velocity = Vector2.zero;
+
+            // 충돌 시 flag 변경 
+            isControllable = false;
+        }   
     }
 
     private void OnCollisionExit2D(Collision2D other)
@@ -252,8 +281,10 @@ public class Blocks : MonoBehaviour
 
         for (int i = 0; i < tiles.Length; i++)
         {
-            Gizmos.DrawRay(tiles[i].transform.position+Vector3.left*0.25f, Vector3.left * 0.45f);
-            Gizmos.DrawRay(tiles[i].transform.position+Vector3.right*0.25f, Vector3.right * 0.45f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.up * 0.22f), Vector3.left * 0.45f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.left*0.25f) + (Vector3.down * 0.22f), Vector3.left * 0.45f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.up * 0.22f), Vector3.right * 0.45f);
+            Gizmos.DrawRay((tiles[i].transform.position+Vector3.right*0.25f) + (Vector3.down * 0.22f), Vector3.right * 0.45f);
         }
     }
 }

--- a/Assets/YSH/Scripts/TestPlayer.cs
+++ b/Assets/YSH/Scripts/TestPlayer.cs
@@ -6,8 +6,40 @@ public class TestPlayer : MonoBehaviour
 {
     [SerializeField] private Blocks currentBlock;
 
+    [SerializeField] private Blocks[] testBlocks;
+
+    private int blockIndex = -1;
+
+    private void Start()
+    {
+        ChangeBlock();
+    }
+
+    // for test
+    private void ChangeBlock()
+    {
+        if (testBlocks.Length <= 0)
+            return;
+
+        blockIndex++;
+
+        if (blockIndex >= testBlocks.Length)
+            blockIndex = 0;
+
+        currentBlock = testBlocks[blockIndex];
+
+        if (!currentBlock.gameObject.activeSelf)
+            currentBlock.gameObject.SetActive(true);
+    }
+
     void Update()
     {
+        // for test
+        if (Input.GetKeyDown(KeyCode.Tab))
+        {
+            ChangeBlock();
+        }
+
         if (Input.GetKey(KeyCode.DownArrow))
             currentBlock.Down();
 

--- a/Assets/YSH/YSH.unity
+++ b/Assets/YSH/YSH.unity
@@ -622,11 +622,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -683,11 +683,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/YSH/YSH.unity
+++ b/Assets/YSH/YSH.unity
@@ -622,11 +622,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -683,11 +683,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/YSH/YSH.unity
+++ b/Assets/YSH/YSH.unity
@@ -122,6 +122,17 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!114 &8535855 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7382279234303379019, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
+  m_PrefabInstance: {fileID: 4930956798240488335}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &53030222
 GameObject:
   m_ObjectHideFlags: 0
@@ -284,7 +295,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 191394021}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -4.5, z: 0}
+  m_LocalPosition: {x: 0, y: -5.25, z: 0}
   m_LocalScale: {x: 2, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -421,8 +432,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1139120333}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -1.7454, z: 0}
-  m_LocalScale: {x: 2, y: 1.5093, z: 1}
+  m_LocalPosition: {x: 0, y: -2.5, z: 0}
+  m_LocalScale: {x: 2, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -532,8 +543,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1626280429}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: -2.2454, z: 0}
-  m_LocalScale: {x: 2, y: 1.5093, z: 1}
+  m_LocalPosition: {x: -0.5, y: -3, z: 0}
+  m_LocalScale: {x: 2, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -584,6 +595,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   currentBlock: {fileID: 3331250099779483131}
+  testBlocks:
+  - {fileID: 3331250099779483131}
+  - {fileID: 8535855}
 --- !u!114 &3331250099779483131 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
@@ -604,11 +618,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.y
@@ -665,15 +679,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.5
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
- BoxBlock mass를 StraightBlock과 동일하게 수정
- 원하는 블럭으로 전환이 가능하도록 테스트 코드 추가
- 단일 레이캐스트 진행 시 높이에 따라 제대로 충돌이 검사되지 않아 타일의 위, 아래에서 이중으로 레이캐스트를 진행하여 정확도를 향상
- 기본 이동량을 0.5에서 0.25로 변경하여 회전시에도 이동량의 차이로 인해 문제가 되지않도록 수정
- 이동량 수정으로 인해 회전시 position을 따로 변경할 필요 없이 단순히 부모 트랜스폼을 기준으로 회전하면 되므로 회전 로직을 단순하게 변경
- 기존 회전의 경우 한번에 각을 바꾸기 때문에 충돌검사가 제대로 이뤄지지 않아 회전시 목표 회전각으로 서서히 회전하도록 하여 충돌 가능하도록 구현하였음