### PR TITLE
[Feat] Wall 충돌 처리, 추락 처리, 이벤트 구조 수정 등 기타 작업

### DIFF
--- a/Assets/YSH/Prefabs/Block1.prefab
+++ b/Assets/YSH/Prefabs/Block1.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 2, y: 0.5}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Prefabs/Block2.prefab
+++ b/Assets/YSH/Prefabs/Block2.prefab
@@ -483,7 +483,7 @@ MonoBehaviour:
   - {fileID: 4930956799183455669}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1, y: 1}
 --- !u!50 &7382279234303379018

--- a/Assets/YSH/Prefabs/Block3.prefab
+++ b/Assets/YSH/Prefabs/Block3.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Prefabs/Block4.prefab
+++ b/Assets/YSH/Prefabs/Block4.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Prefabs/Block5.prefab
+++ b/Assets/YSH/Prefabs/Block5.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Prefabs/Block6.prefab
+++ b/Assets/YSH/Prefabs/Block6.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Prefabs/Block7.prefab
+++ b/Assets/YSH/Prefabs/Block7.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block1.prefab
+++ b/Assets/YSH/Resources/Block1.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 2, y: 0.5}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block2.prefab
+++ b/Assets/YSH/Resources/Block2.prefab
@@ -483,7 +483,7 @@ MonoBehaviour:
   - {fileID: 4930956799183455669}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1, y: 1}
 --- !u!50 &7382279234303379018

--- a/Assets/YSH/Resources/Block3.prefab
+++ b/Assets/YSH/Resources/Block3.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block4.prefab
+++ b/Assets/YSH/Resources/Block4.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block5.prefab
+++ b/Assets/YSH/Resources/Block5.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block6.prefab
+++ b/Assets/YSH/Resources/Block6.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/Block7.prefab
+++ b/Assets/YSH/Resources/Block7.prefab
@@ -147,7 +147,7 @@ MonoBehaviour:
   - {fileID: 5564063099002927774}
   castLayer:
     serializedVersion: 2
-    m_Bits: 12288
+    m_Bits: 12352
   rotateSpeed: 990
   blockSize: {x: 1.5, y: 1}
 --- !u!50 &5564063098573158911

--- a/Assets/YSH/Resources/TestPlayer_Network.prefab
+++ b/Assets/YSH/Resources/TestPlayer_Network.prefab
@@ -54,6 +54,7 @@ MonoBehaviour:
   - {fileID: 5564063098573158910, guid: 409d2bdc2cc1c7e499582a79f60339eb, type: 3}
   - {fileID: 5564063098573158910, guid: d38caaf7b503b834da48f0ea59387ecf, type: 3}
   - {fileID: 5564063098573158910, guid: 1ea15752467a4514b9f9568caed0761b, type: 3}
+  blockCount: 0
 --- !u!114 &8762131031369051194
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -72,7 +73,8 @@ MonoBehaviour:
   Synchronization: 3
   OwnershipTransfer: 0
   observableSearch: 2
-  ObservedComponents: []
+  ObservedComponents:
+  - {fileID: 4503466087411126334}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -270,7 +270,7 @@ public class Blocks : MonoBehaviourPun
 
                 if (resultHit.collider.gameObject.layer == LayerMask.NameToLayer("Wall"))
                 {
-                    Debug.Log("Hit Wall");
+                    Debug.Log("Hit Wall (MoveRoutine)");
                     hitWall = true;
                     break;
                 }
@@ -322,7 +322,7 @@ public class Blocks : MonoBehaviourPun
     {
         if (other.gameObject.layer == LayerMask.NameToLayer("Wall"))
         {
-            Debug.Log("hit wall");
+            Debug.Log("Hit Wall (OnCollision)");
             return;
         }
 

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -42,6 +42,7 @@ public class Blocks : MonoBehaviourPun
     public UnityAction OnBlockExited;       // 블럭이 안착했다가 벗어날 때 (블럭 카운팅에 활용)
     public UnityAction OnDisableControl;    // 블럭의 제어권이 상실될 때 (블럭 스폰에 활용)
   
+    public bool IsControllable { get { return isControllable; } } // 외부에서 제어 가능여부를 확인하기 위한 프로퍼티
     public bool IsEntered { get { return isEntered; } }     // 외부에서 안착여부를 확인하기 위한 프로퍼티
 
     private void Awake()
@@ -391,6 +392,9 @@ public class Blocks : MonoBehaviourPun
         if (other.CompareTag("FallTrigger"))
         {
             OnBlockFallen?.Invoke();
+
+            // 1초 대기 후 삭제
+            Destroy(gameObject, 1f);
         }
     }
 

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -37,10 +37,9 @@ public class Blocks : MonoBehaviourPun
     private Coroutine moveRoutine;          // 이동 시 사용할 코루틴
     private WaitForSeconds wsMoveDelay;     // 이동 코루틴에서 활용할 WaitForSeconds 객체
 
-    public UnityAction OnBlockFallen;       // 블럭이 맵밖으로 떨어질 때 Invoke (체력감소, 사망 처리에 활용)
-    public UnityAction OnBlockEntered;      // 블럭이 안착했을 때 Invoke (블럭 카운팅에 활용)
-    public UnityAction OnBlockExited;       // 블럭이 안착했다가 벗어날 때 (블럭 카운팅에 활용)
-    public UnityAction OnDisableControl;    // 블럭의 제어권이 상실될 때 (블럭 스폰에 활용)
+    public UnityAction<Blocks> OnBlockFallen;       // 블럭이 맵밖으로 떨어질 때 Invoke (체력감소, 사망 처리에 활용)
+    public UnityAction<Blocks> OnBlockEntered;      // 블럭이 안착했을 때 Invoke (블럭 카운팅에 활용)
+    public UnityAction<Blocks> OnBlockExited;       // 블럭이 안착했다가 벗어날 때 (블럭 카운팅에 활용)
   
     public bool IsControllable { get { return isControllable; } } // 외부에서 제어 가능여부를 확인하기 위한 프로퍼티
     public bool IsEntered { get { return isEntered; } }     // 외부에서 안착여부를 확인하기 위한 프로퍼티
@@ -279,9 +278,6 @@ public class Blocks : MonoBehaviourPun
                 // 제어권을 해제
                 isControllable = false;
 
-                // 이벤트 발생
-                OnDisableControl?.Invoke();
-
                 // spotlight 비활성화
                 spotlightObject.SetActive(false);
 
@@ -299,8 +295,6 @@ public class Blocks : MonoBehaviourPun
                 // for debug
                 Debug.Log($"Horizontal Collision : {tiles[i].name} > {resultHit.collider.name}");
                 Debug.Log($"origin : {(Vector2)tiles[i].transform.position}, direction : {lastDir}");
-                SpriteRenderer sr = tiles[i].GetComponent<SpriteRenderer>();
-                sr.color = Color.red;
 
                 yield break;
             }
@@ -335,9 +329,6 @@ public class Blocks : MonoBehaviourPun
 
             // 충돌 시 flag 변경 
             isControllable = false;
-
-            // 이벤트 발생
-            OnDisableControl?.Invoke();
         }
 
         // 충돌체 카운트 증가
@@ -356,12 +347,12 @@ public class Blocks : MonoBehaviourPun
             isEntered = true;
 
             // 이벤트 발생
-            OnBlockEntered?.Invoke();
+            OnBlockEntered?.Invoke(this);
         }
         else
         {
             Debug.Log($"{gameObject.name} not entered");
-        }  
+        }
     }
 
     private void OnCollisionExit2D(Collision2D other)
@@ -383,7 +374,7 @@ public class Blocks : MonoBehaviourPun
         isEntered = false;
 
         // 이벤트 발생
-        OnBlockExited?.Invoke();
+        OnBlockExited?.Invoke(this);
     }
 
     private void OnTriggerExit2D(Collider2D other)
@@ -391,7 +382,7 @@ public class Blocks : MonoBehaviourPun
         // 블럭 추락 여부 확인
         if (other.CompareTag("FallTrigger"))
         {
-            OnBlockFallen?.Invoke();
+            OnBlockFallen?.Invoke(this);
 
             // 1초 대기 후 삭제
             Destroy(gameObject, 1f);

--- a/Assets/YSH/Scripts/TestPlayer_Network.cs
+++ b/Assets/YSH/Scripts/TestPlayer_Network.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class TestPlayer_Network : MonoBehaviourPun
+public class TestPlayer_Network : MonoBehaviourPun, IPunObservable
 {
     [SerializeField] private Blocks currentBlock;
 
@@ -13,6 +13,8 @@ public class TestPlayer_Network : MonoBehaviourPun
     private Blocks[] testBlockInstances;
 
     private int blockIndex = -1;
+
+    [SerializeField] private int blockCount = 0;
 
     private void Start()
     {
@@ -38,11 +40,23 @@ public class TestPlayer_Network : MonoBehaviourPun
             GameObject blockObj = PhotonNetwork.Instantiate(testBlockPrefabs[blockIndex].name, new Vector3(Random.Range(-3, 3), 3.75f, 0), Quaternion.identity);
             testBlockInstances[blockIndex] = blockObj.GetComponent<Blocks>();
             currentBlock = testBlockInstances[blockIndex];
-            Debug.Log($"<color=yellow>${photonView.Owner.NickName} Instantiated Block</color>");
+            currentBlock.OnBlockEntered += BlockEnter;
+            currentBlock.OnBlockExited += BlockExit;
+            Debug.Log($"<color=yellow>{photonView.Owner.NickName} Instantiated Block</color>");
         }    
 
         if (!currentBlock.gameObject.activeSelf)
             currentBlock.gameObject.SetActive(true);
+    }
+
+    private void BlockEnter()
+    {
+        blockCount++;
+    }
+
+    private void BlockExit()
+    {
+        blockCount--;
     }
 
     void Update()
@@ -77,6 +91,18 @@ public class TestPlayer_Network : MonoBehaviourPun
         if (Input.GetKeyDown(KeyCode.Space))
         {
             currentBlock.Rotate();
+        }
+    }
+
+    public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info)
+    {
+        if (stream.IsWriting)
+        {
+            stream.SendNext(blockCount);
+        }
+        else
+        {
+            blockCount = (int)stream.ReceiveNext();
         }
     }
 }

--- a/Assets/YSH/YSH.unity
+++ b/Assets/YSH/YSH.unity
@@ -122,75 +122,75 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &35319012
+--- !u!1001 &48481438
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: -602326007943490617, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: -2110287436322030601, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: sceneViewId
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158883, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_Name
-      value: Block3
+      value: Block4
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158883, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalPosition.y
       value: 3.75
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
---- !u!114 &35319013 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
+--- !u!114 &48481439 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
-  m_PrefabInstance: {fileID: 35319012}
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
+  m_PrefabInstance: {fileID: 48481438}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -282,82 +282,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &97787402
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8643921141320780401, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: sceneViewId
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_Name
-      value: Block6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
---- !u!114 &97787403 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
-  m_PrefabInstance: {fileID: 97787402}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &191394021
 GameObject:
   m_ObjectHideFlags: 0
@@ -469,159 +393,7 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!1001 &538501348
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4785075829512202219, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: sceneViewId
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_Name
-      value: Block5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_RootOrder
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0d147bc042136534591925ff8699d269, type: 3}
---- !u!114 &538501349 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 0d147bc042136534591925ff8699d269, type: 3}
-  m_PrefabInstance: {fileID: 538501348}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &572626168
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4617049557853594254, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: sceneViewId
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_Name
-      value: Block7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_RootOrder
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
---- !u!114 &572626169 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
-  m_PrefabInstance: {fileID: 572626168}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &656115427
+--- !u!1001 &257112081
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -638,7 +410,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7382279234303379016, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
       propertyPath: m_LocalPosition.y
@@ -686,162 +458,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
---- !u!114 &656115428 stripped
+--- !u!114 &257112082 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7382279234303379019, guid: a8effdcfe4ee0634193f70c27cca267a, type: 3}
-  m_PrefabInstance: {fileID: 656115427}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &749878238
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -2110287436322030601, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: sceneViewId
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_Name
-      value: Block4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
---- !u!114 &749878239 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 1a2017d6da2a2c146994a44615212400, type: 3}
-  m_PrefabInstance: {fileID: 749878238}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &1088642340
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 226929390231430516, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: sceneViewId
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_Name
-      value: Block1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158883, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
---- !u!114 &1088642341 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
-  m_PrefabInstance: {fileID: 1088642340}
+  m_PrefabInstance: {fileID: 257112081}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -971,7 +591,7 @@ GameObject:
   - component: {fileID: 1431644057}
   - component: {fileID: 1431644056}
   - component: {fileID: 1431644055}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Wall (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1064,13 +684,317 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1431644054}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.5, y: 0, z: 0}
+  m_LocalPosition: {x: -4.5, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 14.000156, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1449804373
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -602326007943490617, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: sceneViewId
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_Name
+      value: Block3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+--- !u!114 &1449804374 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 319af2a0f8268a64d8cd4e5fb03d35d8, type: 3}
+  m_PrefabInstance: {fileID: 1449804373}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1603671422
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4785075829512202219, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: sceneViewId
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_Name
+      value: Block5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 0d147bc042136534591925ff8699d269, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0d147bc042136534591925ff8699d269, type: 3}
+--- !u!114 &1603671423 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 0d147bc042136534591925ff8699d269, type: 3}
+  m_PrefabInstance: {fileID: 1603671422}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1604372489
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8643921141320780401, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: sceneViewId
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_Name
+      value: Block6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+--- !u!114 &1604372490 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: acc6b5456c9a39149b0f2e8d19ff9d88, type: 3}
+  m_PrefabInstance: {fileID: 1604372489}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1619124576
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 226929390231430516, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: sceneViewId
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_Name
+      value: Block1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+--- !u!114 &1619124577 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 51731620cfa4b9f4b8d527ab7c9aa595, type: 3}
+  m_PrefabInstance: {fileID: 1619124576}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1626280429
 GameObject:
   m_ObjectHideFlags: 0
@@ -1182,6 +1106,82 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1770502988
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4617049557853594254, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: sceneViewId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_Name
+      value: Block7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158883, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5564063098573158909, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+--- !u!114 &1770502989 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5564063098573158910, guid: 82d47b91a8433884ba9285795d98d351, type: 3}
+  m_PrefabInstance: {fileID: 1770502988}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c205cc8e0b9a8648a8893148577abba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2124906542
 GameObject:
   m_ObjectHideFlags: 0
@@ -1193,7 +1193,7 @@ GameObject:
   - component: {fileID: 2124906545}
   - component: {fileID: 2124906544}
   - component: {fileID: 2124906543}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Wall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1286,7 +1286,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2124906542}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.5, y: -0.00000047683716, z: 0}
+  m_LocalPosition: {x: 4.5, y: 0.49999952, z: 0}
   m_LocalScale: {x: 1, y: 13.999241, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1339,10 +1339,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentBlock: {fileID: 0}
   testBlocks:
-  - {fileID: 1088642341}
-  - {fileID: 656115428}
-  - {fileID: 35319013}
-  - {fileID: 749878239}
-  - {fileID: 538501349}
-  - {fileID: 97787403}
-  - {fileID: 572626169}
+  - {fileID: 1619124577}
+  - {fileID: 257112082}
+  - {fileID: 1449804374}
+  - {fileID: 48481439}
+  - {fileID: 1603671423}
+  - {fileID: 1604372490}
+  - {fileID: 1770502989}

--- a/Assets/YSH/YSH_NETWORKTEST.unity
+++ b/Assets/YSH/YSH_NETWORKTEST.unity
@@ -266,7 +266,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.5254902, g: 0.6156863, b: 0.8078432, a: 1}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -284,7 +284,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 191394021}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -5.25, z: 0}
+  m_LocalPosition: {x: -4, y: -5.25, z: 0}
   m_LocalScale: {x: 2, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -361,6 +361,117 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3a57683847d35d04b81bc952dc32fe74, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &655047718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 655047721}
+  - component: {fileID: 655047720}
+  - component: {fileID: 655047719}
+  m_Layer: 12
+  m_Name: Ground (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &655047719
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 655047718}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &655047720
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 655047718}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &655047721
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 655047718}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: -3, z: 0}
+  m_LocalScale: {x: 2, y: 1.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1139120333
 GameObject:
   m_ObjectHideFlags: 0
@@ -447,7 +558,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.5254902, g: 0.6156863, b: 0.8078432, a: 1}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -465,12 +576,234 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1139120333}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -2.5, z: 0}
+  m_LocalPosition: {x: -4, y: -2.5, z: 0}
   m_LocalScale: {x: 2, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1333221066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1333221069}
+  - component: {fileID: 1333221068}
+  - component: {fileID: 1333221067}
+  m_Layer: 12
+  m_Name: Ground (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1333221067
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333221066}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &1333221068
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333221066}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1333221069
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1333221066}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.5, y: -5.25, z: 0}
+  m_LocalScale: {x: 2, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1371808540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1371808543}
+  - component: {fileID: 1371808542}
+  - component: {fileID: 1371808541}
+  m_Layer: 12
+  m_Name: Ground (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1371808541
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371808540}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &1371808542
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371808540}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1371808543
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371808540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.5, y: -2.5, z: 0}
+  m_LocalScale: {x: 2, y: 1.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1626280429
 GameObject:
@@ -558,7 +891,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 0.5254902, g: 0.6156863, b: 0.8078432, a: 1}
+  m_Color: {r: 1, g: 0.39288536, b: 0.0047169924, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -576,7 +909,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1626280429}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: -3, z: 0}
+  m_LocalPosition: {x: -4.5, y: -3, z: 0}
   m_LocalScale: {x: 2, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/YSH/blocks.physicsMaterial2D
+++ b/Assets/YSH/blocks.physicsMaterial2D
@@ -7,5 +7,5 @@ PhysicsMaterial2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: blocks
-  friction: 0.02
+  friction: 0.005
   bounciness: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,7 +12,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - Wall
   - 
   - 
   - 


### PR DESCRIPTION
- 블럭이 홈에 끼이는 문제를 방지하기 위해 마찰 계수를 더욱 감소 조정
- 이동 제한 구역을 정의하기 위한 Wall 레이어를 추가하고 block의 layermask에 추가
- TestPlayer_Network에 blockCount를 추가하고 동기화 하는 코드 추가
- 게임 종료 조건 판단 시 블럭의 isControllable 여부를 참조 할 수 있도록 프로퍼티 추가
- 블럭이 FallTrigger 밖으로 추락하는 경우 블럭을 삭제하도록 처리
- 모든 이벤트 발생 시 이벤트를 발생시키는 block을 전달하도록 수정 하고 OnDisableControl 이벤트 제거