### PR TITLE
[Feat] 블럭 좌우 충돌 시 힘 적용 구현, 블럭 추락 시 Destroy 대기시간 제거

### DIFF
--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -395,8 +395,8 @@ public class Blocks : MonoBehaviourPun
         {
             OnBlockFallen?.Invoke(this);
 
-            // 1초 대기 후 삭제
-            Destroy(gameObject, 1f);
+            // 바로 삭제
+            Destroy(gameObject);
         }
     }
 

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -292,6 +292,17 @@ public class Blocks : MonoBehaviourPun
                     transform.position += new Vector3(toHit.x, 0, 0);
                 }
 
+                // 충돌 시 충돌한 위치를 기준으로 자신에게 반대방향으로 힘을 가한다.
+                rigid.AddForceAtPosition(-lastDir * lastAmount, resultHit.point, ForceMode2D.Impulse);
+
+                // 충돌한 상대 블럭에 대해서도 힘을 가해준다.                
+                // 블럭과 충돌한 경우 리지드바디는 부모에 있기 때문에 GetComponentInParent를 사용
+                Rigidbody2D otherRigid = resultHit.collider.GetComponentInParent<Rigidbody2D>();
+
+                // 결과적으로 상대 오브젝트에서 rigidbody를 찾았으면 힘을 가해준다.
+                if (otherRigid != null)
+                    otherRigid.AddForceAtPosition(lastDir * lastAmount, resultHit.point, ForceMode2D.Impulse);
+
                 // for debug
                 Debug.Log($"Horizontal Collision : {tiles[i].name} > {resultHit.collider.name}");
                 Debug.Log($"origin : {(Vector2)tiles[i].transform.position}, direction : {lastDir}");

--- a/Assets/YSH/YSH.unity
+++ b/Assets/YSH/YSH.unity
@@ -1340,8 +1340,8 @@ MonoBehaviour:
   currentBlock: {fileID: 0}
   testBlocks:
   - {fileID: 1619124577}
-  - {fileID: 257112082}
   - {fileID: 1449804374}
+  - {fileID: 257112082}
   - {fileID: 48481439}
   - {fileID: 1603671423}
   - {fileID: 1604372490}


### PR DESCRIPTION
- 블럭 좌우 충돌 시에 힘을 가해주어 자연스러운 물리 처리가 되도록 수정
- PlayerController에서 블럭 추락 후 새 블럭을 스폰하기 전에 이전 블럭을 바로 파괴 하기 위해 대기시간 제거