### PR TITLE
[Feat] 블럭 Freeze 구현, 블럭 물리 및 추락 개선

### DIFF
--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -373,12 +373,14 @@ public class Blocks : MonoBehaviourPun
 
         if (isControllable)
         {
+            rigid.simulated = false;
             rigid.velocity = Vector2.zero;
-
-            spotlightObject.SetActive(false);
+            rigid.angularVelocity = 0;
+            rigid.simulated = true;
 
             // 충돌 시 flag 변경 
             isControllable = false;
+            spotlightObject.SetActive(false);
         }
 
         // 충돌체 카운트 증가

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 
 public class Blocks : MonoBehaviourPun
 {
+    #region Serialize Field
     [SerializeField] private float basicFallSpeed;          // 하강 속도
     [SerializeField] private float fastFallSpeed;           // 빠른 하강 속도
     [SerializeField] private GameObject spotlightObject;    // spotlight 오브젝트
@@ -18,7 +19,9 @@ public class Blocks : MonoBehaviourPun
     [SerializeField] private LayerMask castLayer;           // 레이캐스트용 layermask
     [SerializeField] private float rotateSpeed;             // 회전 속도
     [SerializeField] private Vector2 blockSize;             // 블럭 사이즈 (타일 하나당 0.5로 계산)
+    #endregion
 
+    #region Private Field
     private Rigidbody2D rigid;              // Rigidbody2D 컴포넌트 참조                                          
     private Vector2 currentVelocity;        // 현재 하강 속도
     private Vector2 currentDirection;       // 현재 이동 방향
@@ -37,12 +40,18 @@ public class Blocks : MonoBehaviourPun
     private Coroutine moveRoutine;          // 이동 시 사용할 코루틴
     private WaitForSeconds wsMoveDelay;     // 이동 코루틴에서 활용할 WaitForSeconds 객체
 
+    private TestPlayer owner;         // 자신을 생성한 Player
+    #endregion
+
+    #region Public Field
     public UnityAction<Blocks> OnBlockFallen;       // 블럭이 맵밖으로 떨어질 때 Invoke (체력감소, 사망 처리에 활용)
     public UnityAction<Blocks> OnBlockEntered;      // 블럭이 안착했을 때 Invoke (블럭 카운팅에 활용)
     public UnityAction<Blocks> OnBlockExited;       // 블럭이 안착했다가 벗어날 때 (블럭 카운팅에 활용)
   
     public bool IsControllable { get { return isControllable; } } // 외부에서 제어 가능여부를 확인하기 위한 프로퍼티
     public bool IsEntered { get { return isEntered; } }     // 외부에서 안착여부를 확인하기 위한 프로퍼티
+    public TestPlayer Owner { get { return owner; } } // 외부에서 블럭 Owner를 확인하기 위한 프로퍼티
+    #endregion
 
     private void Awake()
     {
@@ -50,7 +59,7 @@ public class Blocks : MonoBehaviourPun
         rigid = GetComponent<Rigidbody2D>();
     }
 
-    void Start()
+    private void Start()
     {
         isControllable = true;
         wsMoveDelay = new WaitForSeconds(moveDelay);
@@ -73,7 +82,7 @@ public class Blocks : MonoBehaviourPun
         currentVelocity = new Vector2(rigid.velocity.x, basicFallSpeed);
     }
 
-    void Update()
+    private void Update()
     {
         // 타워나 블럭에 부딪힌 이후부터는 해당 블럭에 대한 조작 불가능
         if (!isControllable)
@@ -122,6 +131,14 @@ public class Blocks : MonoBehaviourPun
         }
     }
 
+    public void SetOwner(TestPlayer player)
+    {
+        // owner 참조
+        owner = player;
+        // 이벤트 구독
+        owner.OnPlayerDone += Freeze;
+    }
+
     // Player의 빠른 하강 조작을 위한 Interface
     public void Down()
     {
@@ -158,6 +175,28 @@ public class Blocks : MonoBehaviourPun
 
         // flag set
         isRotate = true;
+    }
+
+    private void Freeze()
+    {
+        // 조작 불가 상태로 변경
+        isControllable = false;
+
+        if (rigid != null)
+        {
+            // 더 이상 물리처리 하지 않도록 변경
+            rigid.simulated = false;
+            // velocity 초기화
+            rigid.velocity = Vector2.zero;
+        }
+
+        SpriteRenderer sr;
+        foreach (GameObject tile in tiles)
+        {
+            sr = tile.GetComponent<SpriteRenderer>();
+            // sprite color를 변경하여 freeze 상태를 확인할 수 있도록 함
+            sr.color = Color.gray;
+        }
     }
 
     private void SetSpotlight()

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -393,6 +393,14 @@ public class Blocks : MonoBehaviourPun
         // 블럭 추락 여부 확인
         if (other.CompareTag("FallTrigger"))
         {
+            // 블럭의 y위치가 카메라 y위치보다 높으면 처리하지 않는다. (예외 방지)
+            if (transform.position.y >= Camera.main.transform.position.y)
+            {
+                Debug.Log("<color=red>Block is higher than camera</color>");
+                return;
+            }
+
+            // 이벤트 발생
             OnBlockFallen?.Invoke(this);
 
             // 바로 삭제

--- a/Assets/YSH/Scripts/TestPlayer.cs
+++ b/Assets/YSH/Scripts/TestPlayer.cs
@@ -3,6 +3,7 @@ using Photon.Pun.Demo.Procedural;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class TestPlayer : MonoBehaviourPun
 {
@@ -11,6 +12,32 @@ public class TestPlayer : MonoBehaviourPun
     [SerializeField] private Blocks[] testBlocks;
 
     private int blockIndex = -1;
+
+    bool isGoal = false;
+
+    bool IsGoal 
+    { 
+        get { return isGoal; }
+        set 
+        {
+            isGoal = value;
+            if (isGoal == true)
+                OnPlayerDone?.Invoke(); 
+        } 
+    }
+
+    public UnityAction OnPlayerDone; 
+
+    private void Awake()
+    {
+        if (testBlocks.Length <= 0)
+            return;
+
+        foreach (Blocks block in testBlocks)
+        {
+            block.SetOwner(this);
+        }
+    }
 
     private void Start()
     {
@@ -36,10 +63,18 @@ public class TestPlayer : MonoBehaviourPun
 
     void Update()
     {
+        if (isGoal)
+            return;
+
         // for test
         if (Input.GetKeyDown(KeyCode.Tab))
         {
             ChangeBlock();
+        }
+
+        if (Input.GetKeyDown(KeyCode.G))
+        {
+            IsGoal = true;
         }
 
         if (currentBlock == null)

--- a/Assets/YSH/blocks.physicsMaterial2D
+++ b/Assets/YSH/blocks.physicsMaterial2D
@@ -7,5 +7,5 @@ PhysicsMaterial2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: blocks
-  friction: 0.005
+  friction: 0.3
   bounciness: 0


### PR DESCRIPTION
- 블럭이 자신을 생성한 플레이어가 goal 상태가 되면 freeze 되도록 구현
- 테스트를 위해 Owner는 TestPlayer 타입으로 선언하였으며 이는 추후 PlayerController에 내용이 추가되면 변경 예정
- 블럭들이 어느 정도 마찰을 통해 절묘하게 끼이는 경우를 생각하여 마찰 계수를 상향 조정
- 블럭이 최초로 어떤 물체에 부딪힐 때 일시적으로 속도 및 물리 처리를 리셋하여 블럭이 걸쳐질 수 있을만한 지형이라면 걸쳐질 수 있도록 개선 (추후 문제가 발생하는 경우 롤백)
- 블럭이 fallTrigger를 벗어날 시 실제 위치가 카메라보다 낮은지 확인하여 추락 처리하도록 수정