### PR TITLE
[Fix] 패널티로 인한 타워 상승 시 블럭 처리 

### DIFF
--- a/Assets/Jun/Scripts/PlayerController.cs
+++ b/Assets/Jun/Scripts/PlayerController.cs
@@ -34,6 +34,9 @@ public class PlayerController : MonoBehaviourPun, IPunObservable
     public event Action OnFallenOffTheCamera;
     public event Action OnPlayerDone;
 
+    // test
+    public event Action<bool> OnProcessPanalty;
+
     public int TowerNumber = 0;
 
     [Header("PlayerUI")]
@@ -88,6 +91,12 @@ public class PlayerController : MonoBehaviourPun, IPunObservable
         {
             PlayerInput();
         }
+    }
+
+    // test
+    public void ProcessPanalty(bool bProcessing)
+    {
+        OnProcessPanalty?.Invoke(bProcessing);
     }
 
     private void PlayerInput()

--- a/Assets/KwakSeongDae/Scripts/GameStates/PuzzleModeState.cs
+++ b/Assets/KwakSeongDae/Scripts/GameStates/PuzzleModeState.cs
@@ -113,7 +113,8 @@ public class PuzzleModeState : GameState
                     || dif.y < -0.01f)
                 {
                     towerObjectDic[playerID].GetComponent<Rigidbody2D>().velocity = Vector2.zero;
-                    towerObjectDic[playerID].transform.position = targetTowerPos;
+                    //towerObjectDic[playerID].transform.position = targetTowerPos;
+                    towerObjectDic[playerID].GetComponent<Rigidbody2D>().position = targetTowerPos;
                     isMoveTower = false;
                     // 플레이어에 패널티 처리 종료 알림
                     playerObjectDic[playerID].GetComponent<PlayerController>().ProcessPanalty(false);
@@ -122,7 +123,8 @@ public class PuzzleModeState : GameState
             else
             {
                 // 타겟 타워 위치 초기화
-                targetTowerPos = towerObjectDic[playerID].transform.position;
+                //targetTowerPos = towerObjectDic[playerID].transform.position;
+                targetTowerPos = towerObjectDic[playerID].GetComponent<Rigidbody2D>().position;
             }
         }
     }

--- a/Assets/KwakSeongDae/Scripts/GameStates/PuzzleModeState.cs
+++ b/Assets/KwakSeongDae/Scripts/GameStates/PuzzleModeState.cs
@@ -92,6 +92,8 @@ public class PuzzleModeState : GameState
         // 해당 타워는 photonView transform이므로 자동으로 위치 동기화
         targetTowerPos = (Vector2)towerObjectDic[playerID].transform.position + Vector2.up * towerHeightStep;
         towerObjectDic[playerID].GetComponent<Rigidbody2D>().velocity = Vector2.up * towerSpeed;
+        // 플레이어에 패널티 처리 알림
+        playerObjectDic[playerID].GetComponent<PlayerController>().ProcessPanalty(true);
         isMoveTower = true;
         // 블럭이 동시에 떨어지는 경우, 중복 실행 방지
         yield return new WaitForSeconds(1f);
@@ -113,6 +115,8 @@ public class PuzzleModeState : GameState
                     towerObjectDic[playerID].GetComponent<Rigidbody2D>().velocity = Vector2.zero;
                     towerObjectDic[playerID].transform.position = targetTowerPos;
                     isMoveTower = false;
+                    // 플레이어에 패널티 처리 종료 알림
+                    playerObjectDic[playerID].GetComponent<PlayerController>().ProcessPanalty(false);
                 }
             }
             else

--- a/Assets/KwakSeongDae/Scripts/Tools/Tower.cs
+++ b/Assets/KwakSeongDae/Scripts/Tools/Tower.cs
@@ -3,13 +3,28 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Tower : MonoBehaviourPun
+public class Tower : MonoBehaviourPun, IPunObservable
 {
+    private Rigidbody2D rigid;
+
     void Awake()
     {
         object[] data = photonView.InstantiationData;
         gameObject.name = $"Tower{data[0]}";
 
         GetComponent<BlockMaxHeightManager>().gameState = PhotonView.Find((int)data[1]).GetComponent<GameState>();
+        rigid = GetComponent<Rigidbody2D>();
+    }
+
+    public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info)
+    {
+        if (stream.IsWriting)
+        {
+            stream.SendNext(rigid.position);
+        }
+        else
+        {
+            rigid.position = (Vector2)(stream.ReceiveNext());
+        }
     }
 }

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -51,6 +51,7 @@ MonoBehaviour:
   - SelectModeButton1
   - SelectModeButton2
   - SelectModeButton3
+  - ChangeDragRPC
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Release/Resources/Block1.prefab
+++ b/Assets/Release/Resources/Block1.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 2, y: 0.5}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Release/Resources/Block2.prefab
+++ b/Assets/Release/Resources/Block2.prefab
@@ -486,6 +486,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1, y: 1}
+  panaltyDrag: 100
 --- !u!50 &7382279234303379018
 Rigidbody2D:
   serializedVersion: 4
@@ -528,7 +529,6 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: 7382279234303379019}
   - {fileID: 4413704574581602890}
-  - {fileID: 0}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0

--- a/Assets/Release/Resources/Block3.prefab
+++ b/Assets/Release/Resources/Block3.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1.5, y: 1}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4
@@ -192,7 +193,6 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: 5564063098573158910}
   - {fileID: -3425896520314207198}
-  - {fileID: 0}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0

--- a/Assets/Release/Resources/Block4.prefab
+++ b/Assets/Release/Resources/Block4.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1.5, y: 1}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Release/Resources/Block5.prefab
+++ b/Assets/Release/Resources/Block5.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1.5, y: 1}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Release/Resources/Block6.prefab
+++ b/Assets/Release/Resources/Block6.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1.5, y: 1}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Release/Resources/Block7.prefab
+++ b/Assets/Release/Resources/Block7.prefab
@@ -150,6 +150,7 @@ MonoBehaviour:
     m_Bits: 12352
   rotateSpeed: 25
   blockSize: {x: 1.5, y: 1}
+  panaltyDrag: 100
 --- !u!50 &5564063098573158911
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Release/Resources/Tower.prefab
+++ b/Assets/Release/Resources/Tower.prefab
@@ -4857,6 +4857,7 @@ MonoBehaviour:
   observableSearch: 2
   ObservedComponents:
   - {fileID: 7571176543749973335}
+  - {fileID: 6735788521809538095}
   - {fileID: 3893083601067190758}
   sceneViewId: 0
   InstantiationId: 0

--- a/Assets/Release/Resources/Tower.prefab
+++ b/Assets/Release/Resources/Tower.prefab
@@ -9514,8 +9514,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6734055021281785465}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2, y: -35, z: -10}
-  m_LocalScale: {x: 33.333332, y: 2, z: 1}
+  m_LocalPosition: {x: 0, y: -35, z: -10}
+  m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3161169293038133173}
@@ -9545,7 +9545,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 27.776556, y: 18}
+  m_Size: {x: 28, y: 18}
   m_EdgeRadius: 0
 --- !u!1 &6739042434388512210
 GameObject:

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -151,6 +151,12 @@ public class Blocks : MonoBehaviourPun, IPunObservable
 
     public void ChangeDrag(bool bPanalty)
     {
+        photonView.RPC("ChangeDragRPC", RpcTarget.All, bPanalty);
+    }
+
+    [PunRPC]
+    private void ChangeDragRPC(bool bPanalty)
+    {
         // 타워 상승 진행 시
         if (bPanalty)
         {
@@ -483,20 +489,15 @@ public class Blocks : MonoBehaviourPun, IPunObservable
         // 블럭 추락 여부 확인
         if (other.CompareTag("FallTrigger"))
         {
+            if (owner != null)
+            {
+                owner.OnPlayerDone -= Freeze;
+                owner.OnProcessPanalty -= ChangeDrag;
+            }
             // 이벤트 발생
             OnBlockFallen?.Invoke(this);
             // 바로 삭제
             Destroy(gameObject);
-        }
-    }
-
-    // 이벤트 해제
-    private void OnDestroy()
-    {
-        if (owner != null)
-        {
-            owner.OnPlayerDone -= Freeze;
-            owner.OnProcessPanalty -= ChangeDrag;
         }
     }
 
@@ -522,14 +523,12 @@ public class Blocks : MonoBehaviourPun, IPunObservable
             stream.SendNext(rigid.simulated);
             stream.SendNext(rigid.rotation);
             stream.SendNext(rigid.position);
-            stream.SendNext(rigid.drag);
         }
         else
         {
             rigid.simulated = (bool)stream.ReceiveNext();
             rigid.rotation = (float)stream.ReceiveNext();
             rigid.position = (Vector2)(stream.ReceiveNext());
-            rigid.drag = (float)stream.ReceiveNext();
         }
     }
 }

--- a/Assets/YSH/Scripts/Blocks.cs
+++ b/Assets/YSH/Scripts/Blocks.cs
@@ -18,7 +18,8 @@ public class Blocks : MonoBehaviourPun, IPunObservable
     [SerializeField] private GameObject[] tiles;            // 블럭 타일들
     [SerializeField] private LayerMask castLayer;           // 레이캐스트용 layermask
     [SerializeField] private float rotateSpeed;             // 회전 속도
-    [SerializeField] private Vector2 blockSize;             // 블럭 사이즈 (타일 하나당 0.5로 계산)
+    [SerializeField] private Vector2 blockSize;             // 블럭 사이즈 (타일 하나당 0.5로 계산)  
+    [SerializeField] private float panaltyDrag;             // 타워 상승 시 적용할 Drag
     #endregion
 
     #region Private Field
@@ -36,6 +37,7 @@ public class Blocks : MonoBehaviourPun, IPunObservable
     private bool isVertical = false;        // 회전 상태를 확인하기 위한 flag
 
     private int collisionCount = 0;         // 현재 블럭과 충돌해있는 충돌체의 수 (exit 판정에 사용)
+    private float normalDrag;               // 일반 상태의 Drag 수치 (최초 설정된 Drag) 
 
     private Coroutine moveRoutine;          // 이동 시 사용할 코루틴
     private WaitForSeconds wsMoveDelay;     // 이동 코루틴에서 활용할 WaitForSeconds 객체
@@ -59,6 +61,9 @@ public class Blocks : MonoBehaviourPun, IPunObservable
     {
         // 컴포넌트 참조
         rigid = GetComponent<Rigidbody2D>();
+
+        // 최초 Drag 저장
+        normalDrag = rigid.drag;
     }
 
     private void Start()
@@ -144,12 +149,33 @@ public class Blocks : MonoBehaviourPun, IPunObservable
         freezeRotateRoutine = null;
     }
 
+    public void ChangeDrag(bool bPanalty)
+    {
+        // 타워 상승 진행 시
+        if (bPanalty)
+        {
+            // 안착해있는 블럭인 경우
+            if (isEntered)
+            {
+                rigid.drag = panaltyDrag;
+                rigid.velocity = Vector2.zero;
+            }
+        }
+        // 타워 상승 종료 시
+        else
+        {
+            rigid.drag = normalDrag;
+            rigid.velocity = Vector2.zero;
+        }
+    }
+
     public void SetOwner(PlayerController player)
     {
         // owner 참조
         owner = player;
         // 이벤트 구독
         owner.OnPlayerDone += Freeze;
+        owner.OnProcessPanalty += ChangeDrag;
     }
 
     // Player의 빠른 하강 조작을 위한 Interface
@@ -418,8 +444,6 @@ public class Blocks : MonoBehaviourPun, IPunObservable
         if (isEntered)
             return;
 
-        //Debug.Log($"{gameObject.name} entered");
-
         // enter flag set
         isEntered = true;
 
@@ -447,8 +471,6 @@ public class Blocks : MonoBehaviourPun, IPunObservable
         if (collisionCount > 0)
             return;
 
-        //Debug.Log($"{gameObject.name} exited");
-
         // enter flag set
         isEntered = false;
 
@@ -463,9 +485,18 @@ public class Blocks : MonoBehaviourPun, IPunObservable
         {
             // 이벤트 발생
             OnBlockFallen?.Invoke(this);
-            if (owner != null) owner.OnPlayerDone -= Freeze;
             // 바로 삭제
             Destroy(gameObject);
+        }
+    }
+
+    // 이벤트 해제
+    private void OnDestroy()
+    {
+        if (owner != null)
+        {
+            owner.OnPlayerDone -= Freeze;
+            owner.OnProcessPanalty -= ChangeDrag;
         }
     }
 
@@ -491,25 +522,14 @@ public class Blocks : MonoBehaviourPun, IPunObservable
             stream.SendNext(rigid.simulated);
             stream.SendNext(rigid.rotation);
             stream.SendNext(rigid.position);
-            //print($"Sender: {rigid.position}");
+            stream.SendNext(rigid.drag);
         }
         else
         {
             rigid.simulated = (bool)stream.ReceiveNext();
             rigid.rotation = (float)stream.ReceiveNext();
-            //print($"Reciever: {(Vector2)(stream.ReceiveNext())}");
             rigid.position = (Vector2)(stream.ReceiveNext());
+            rigid.drag = (float)stream.ReceiveNext();
         }
     }
-
-    //private void LateUpdate()
-    //{
-    //    // 회전하는 경우에는 x값 위치 보정
-    //    if (isRotate)
-    //    {
-    //        var x = Mathf.Round(rigid.position.x / 0.25f) * 0.25f;
-    //        rigid.position = new Vector2(x, rigid.position.y);
-    //        print($"회전 후, 위치 조정{x}");
-    //    }
-    //}
 }


### PR DESCRIPTION
- 퍼즐 모드에서 패널티로 인해 타워 상승 시 블럭이 밀리지 않도록 처리
- 타워의 rigidbody position을 동기화하도록 추가
- PuzzleModeState에서 transform이 아닌 rigidbody의 position을 제어하도록 변경
- FallTrigger width 크기가 너무 커 다른 플레이어에 영향을 미치므로 크기를 수정